### PR TITLE
readme updated - use url() helper when passing a url to the Navigator::hideItem() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ You can explicitly hide menu items from all users by marking an item as hidden. 
 $navigator = \Navigator::get();
 
 // Hide an item from the default menu. You have to pass the Item ID, which is the URL by default.
-\Navigator::hideItem('/projects');
+\Navigator::hideItem(url('/projects'));
 
 // Hiden an item from another menu
-\Navigator::hideItem('/settings', 'second-menu-name');
+\Navigator::hideItem(url('/settings'), 'second-menu-name');
 ```
 
 Example on how to render Navigation within a Blade template


### PR DESCRIPTION
We have to pass the full URL as the $itemId to the \Navigator::hideItem() method. Otherwise, it won't match any NavBar items and menu items won't get hidden. I've discovered this while trying to hide a dashboard menu item based on the instructions shown in the README. It didn't work and I had to dig deep to understand how NavItem works internally. 